### PR TITLE
Fix plumes for single way RCS parts, improve syntax, other things

### DIFF
--- a/GameData/z_BetterRCS/Patches/BetterRCS_Regex.cfg
+++ b/GameData/z_BetterRCS/Patches/BetterRCS_Regex.cfg
@@ -12,7 +12,7 @@
 
 // REGEX PASS - Where the magic is applied.
 
-@PART:HAS[@MODULE[ModuleRCSFX],!MODULE[BetterRCSDisabledTag]]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
+@PART:HAS[@MODULE[ModuleRCSFX],@MODULE[ModuleWaterfallFX],!MODULE[BetterRCSDisabledTag]]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleRCSFX],*
 	{
@@ -50,14 +50,14 @@
 		{
 			@key,* ^= :1700\.9 ::
 			@key,*[0, ] -= 245
-			@key,* ^= :^[^\d\.].\S*\s*$:Vac_LowPressure: // If the Vacuum ISP is below 245, VacLP
+			@key,* ^= :^[^\d\.].\S*\s*$:Vac_LowPressure:	// If the Vacuum ISP is below 245, VacLP
 		}
 
 		@var_CurveISP_SLParse:HAS[#key[*4421*]]
 		{
 			@key,* ^= :4421 ::
 			@key,*[0, ] -= 80
-			@key,* ^= :^[^\d\.].\S*\s*$:SL_LowPressure: // If the Sea Level ISP is below 80, SLLP
+			@key,* ^= :^[^\d\.].\S*\s*$:SL_LowPressure:	// If the Sea Level ISP is below 80, SLLP
 		}
 	}
 }

--- a/GameData/z_BetterRCS/Patches/BetterRCS_Regex.cfg
+++ b/GameData/z_BetterRCS/Patches/BetterRCS_Regex.cfg
@@ -2,7 +2,7 @@
 // Basically we want to exclude certain types of thrusters like electric thrusters which will usually have a unique plume
 // or thrusters that are intentionally disabled in the config.
 
-@PART[*]:HAS[@MODULE[ModuleRCSFX]:HAS[PROPELLANT[ElectricCharge]]]
+@PART:HAS[@MODULE[ModuleRCSFX]:HAS[PROPELLANT[ElectricCharge]]]
 {
 	MODULE
 	{
@@ -12,60 +12,63 @@
 
 // REGEX PASS - Where the magic is applied.
 
-@PART[*]:HAS[@MODULE[ModuleRCSFX],@MODULE[ModuleWaterfallFX],!MODULE[BetterRCSDisabledTag]]:FOR[z_BetterRCS]:NEEDS[Waterfall,!ROWaterfall]
+@PART:HAS[@MODULE[ModuleRCSFX],!MODULE[BetterRCSDisabledTag]]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleRCSFX],*
 	{
-	+atmosphereCurve 
+		+atmosphereCurve 
 		{
 			|. = var_CurveISP
 			@key,* ^= :\s+: :
 			@key,*[0, ] -= 0.1
-			@key,*[0, ] ^= :^[^\d\.].*:1701.9: // Vacuum ISP confirmed
+			@key,*[0, ] ^= :^[^\d\.].*:1701.9:	// Vacuum ISP confirmed
 		}	
-		
-	@var_CurveISP:HAS[#key[*1701.9*]]
+
+		@var_CurveISP:HAS[#key[*1701.9*]]
 		{
 			@key,*[0, ] -= 0.8
-			@key,*[0, ] ^= :^[^\d\.].*:696969: // Evil ISP
+			@key,*[0, ] ^= :^[^\d\.].*:696969:	// Evil ISP
 		}
-		
-	@var_CurveISP:HAS[#key[*1701.1*]]
+
+		@var_CurveISP:HAS[#key[*1701.1*]]
 		{
 			@key,*[0, ] -= 0.2
-			@key,*[0, ] ^= :^[^\d\.].*:4421: // Sea Level ISP confirmed
+			@key,*[0, ] ^= :^[^\d\.].*:4421:	// Sea Level ISP confirmed
 		}
+
 		+var_CurveISP
-			{
-				|. = var_CurveISP_VacParse
-			}
+		{
+			|. = var_CurveISP_VacParse
+		}
+
 		+var_CurveISP
-			{
-				|. = var_CurveISP_SLParse
-			}
-		
-	@var_CurveISP_VacParse:HAS[#key[*1700.9*]]
+		{
+			|. = var_CurveISP_SLParse
+		}
+
+		@var_CurveISP_VacParse:HAS[#key[*1700.9*]]
 		{
 			@key,* ^= :1700\.9 ::
 			@key,*[0, ] -= 245
 			@key,* ^= :^[^\d\.].\S*\s*$:Vac_LowPressure: // If the Vacuum ISP is below 245, VacLP
 		}
-		
-	@var_CurveISP_SLParse:HAS[#key[*4421*]]
+
+		@var_CurveISP_SLParse:HAS[#key[*4421*]]
 		{
 			@key,* ^= :4421 ::
 			@key,*[0, ] -= 80
 			@key,* ^= :^[^\d\.].\S*\s*$:SL_LowPressure: // If the Sea Level ISP is below 80, SLLP
 		}
-		
 	}
 }
 
 // FIX PASS - Specific thrusters are sometimes very broken, like the Vernor, this is where they get their special care to actually function
 
-@PART[vernierEngine]:FOR[z_BetterRCS]:NEEDS[Waterfall,!ROWaterfall]
+// Stock thrusters
+
+@PART[vernierEngine]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
 {
-	!MODULE[ModuleWaterfallFX],1 {}
+	//!MODULE[ModuleWaterfallFX],1 {}	// <-------- this line deletes the waterfall module, so no effects show up
 	@MODULE[ModuleWaterfallFX],0
 	{
 		@TEMPLATE
@@ -78,24 +81,24 @@
 	}
 }
 
-@PART[RCSLinearSmall]:FOR[z_BetterRCS]:NEEDS[Waterfall,!ROWaterfall]
+@PART[RCSLinearSmall]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]
 	{
-		!TEMPLATE,1 {}
-		@TEMPLATE,0
+		//!TEMPLATE,1 {}		// <-------- this line deletes the template block in the waterfall module, so no effects show up
+		@TEMPLATE:NEEDS[Restock]
 		{
-			@position = 0,0,0
+			@position = 0,0.06,0
 			@scale = 0.35,0.35,0.35
 		}
 	}
 }
 
-@PART[linearRcs]:HAS[!MODULE[BetterRCSDisabledTag]]:FOR[z_BetterRCS]:NEEDS[Waterfall,!ROWaterfall]
+@PART[linearRcs]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]
 	{
-		!TEMPLATE,1 {}
+		//!TEMPLATE,1 {}		// <-------- this line deletes the template block in the waterfall module, so no effects show up
 		@TEMPLATE,0
 		{
 			@position = 0,-0.04,0
@@ -103,7 +106,68 @@
 	}
 }
 
-@PART[nesdIR-GM]:HAS[!MODULE[BetterRCSDisabledTag]]:FOR[z_BetterRCS]:NEEDS[InternalRCS,!ROWaterfall]
+// Position fixes - some plumes are slightly offset, these patches improve them ever so slightly
+// I've tested for both Stock and Restock models, so this should work for most game installs
+
+@PART[RCSBlock_v2]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
+{
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE:NEEDS[!Restock]
+		{
+			@position = 0,0.04,0
+		}
+
+		@TEMPLATE:NEEDS[Restock]
+		{
+			@position = 0,-0.015,0
+		}
+	}
+}
+
+@PART[RCSblock_01_small]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
+{
+
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE:NEEDS[!Restock]
+		{
+			@position = 0,0.04,0
+		}
+
+		@TEMPLATE:NEEDS[Restock]
+		{
+			@position = 0,-0.007,0
+		}
+	}
+}
+
+@PART[mk1-3pod]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
+{
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE:NEEDS[!Restock]
+		{
+			@position = 0,-0.05,0
+			@scale = 1,1,1
+		}
+	}
+}
+
+@PART[MEMLander]:NEEDS[SquadExpansion/MakingHistory,Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
+{
+	@MODULE[ModuleWaterfallFX]
+	{
+		@TEMPLATE
+		{
+			@position = 0,-0.04,0
+		}
+	}
+}
+
+// InternalRCS thrusters
+
+@PART[nesdIR-GM]:HAS[!MODULE[BetterRCSDisabledTag]]:NEEDS[InternalRCS,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]
 	{
@@ -114,7 +178,7 @@
 	}
 }
 
-@PART[nesdIRmp*]:HAS[!MODULE[BetterRCSDisabledTag]]:FOR[z_BetterRCS]:NEEDS[InternalRCS,!ROWaterfall]
+@PART[nesdIRmp*]:HAS[!MODULE[BetterRCSDisabledTag]]:NEEDS[InternalRCS,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]
 	{
@@ -127,7 +191,7 @@
 	}
 }
 
-@PART[nesdIRhl*]:HAS[!MODULE[BetterRCSDisabledTag]]:FOR[z_BetterRCS]:NEEDS[InternalRCSPlus,!ROWaterfall]
+@PART[nesdIRhl*]:HAS[!MODULE[BetterRCSDisabledTag]]:NEEDS[InternalRCSPlus,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]
 	{
@@ -140,7 +204,7 @@
 	}
 }
 
-@PART[nesdIRml*]:HAS[!MODULE[BetterRCSDisabledTag]]:FOR[z_BetterRCS]:NEEDS[InternalRCSPlus,!ROWaterfall]
+@PART[nesdIRml*]:HAS[!MODULE[BetterRCSDisabledTag]]:NEEDS[InternalRCSPlus,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]
 	{
@@ -153,7 +217,7 @@
 	}
 }
 
-@PART[nesdIRmp1eng|nesdIRmp2eng|nesdIRmp3eng|nesdIRmp4eng|nesdIRmp5eng]:HAS[!MODULE[BetterRCSDisabledTag]]:FOR[z_BetterRCS]:NEEDS[InternalRCS,!ROWaterfall]
+@PART[nesdIRmp1eng|nesdIRmp2eng|nesdIRmp3eng|nesdIRmp4eng|nesdIRmp5eng]:HAS[!MODULE[BetterRCSDisabledTag]]:NEEDS[InternalRCS,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]
 	{
@@ -171,8 +235,9 @@
 	}
 }
 
+// TundraExploration thrusters
 
-@PART[TE_18_DRAGONV2_POD|TE_18_DRAGONV2_POD_I4|TE_20_CargoRodan]:FOR[z_BetterRCS]:HAS[!MODULE[BetterRCSDisabledTag]]:NEEDS[TundraExploration,!ROWaterfall]
+@PART[TE_18_DRAGONV2_POD|TE_18_DRAGONV2_POD_I4|TE_20_CargoRodan]:HAS[!MODULE[BetterRCSDisabledTag]]:NEEDS[TundraExploration,!ROWaterfall]:FOR[z_BetterRCS]
 {
 
 	@MODULE[ModuleWaterfallFX],1
@@ -195,7 +260,7 @@
 	}
 }
 
-@PART[TE_21_DXL_Docking]:FOR[z_BetterRCS]:HAS[!MODULE[BetterRCSDisabledTag]]:NEEDS[TundraExploration,!ROWaterfall]
+@PART[TE_21_DXL_Docking]:HAS[!MODULE[BetterRCSDisabledTag]]:NEEDS[TundraExploration,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]
 	{
@@ -206,7 +271,7 @@
 	}
 }
 
-@PART[TE_21_DXL_RCS]:FOR[z_BetterRCS]:HAS[!MODULE[BetterRCSDisabledTag]]:NEEDS[TundraExploration,!ROWaterfall]
+@PART[TE_21_DXL_RCS]:HAS[!MODULE[BetterRCSDisabledTag]]:NEEDS[TundraExploration,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]
 	{
@@ -218,7 +283,7 @@
 	}
 }
 
-@PART[TE2_19_F9_CGT]:HAS[!MODULE[BetterRCSDisabledTag]]:FOR[z_BetterRCS]:NEEDS[TundraExploration,!ROWaterfall]
+@PART[TE2_19_F9_CGT]:HAS[!MODULE[BetterRCSDisabledTag]]:NEEDS[TundraExploration,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]
 	{
@@ -234,9 +299,10 @@
 	}
 }
 
-// POSTFIX PASS - This runs AFTER everything else, but is placed before SCALE and ALLOCATION for ease of reading, this is for special cases where BetterRCS accidentally replaces a plume that shouldn't be replaced
+// POSTFIX PASS - This runs AFTER everything else, but is placed before SCALE and ALLOCATION for ease of reading
+// This is for special cases where BetterRCS accidentally replaces a plume that shouldn't be replaced
 
-@PART[TE_18_DRAGONV2_POD|TE_18_DRAGONV2_POD_I4|TE_20_CargoRodan]:HAS[!MODULE[BetterRCSDisabledTag]]:AFTER[z_BetterRCS]:NEEDS[TundraExploration,!ROWaterfall]
+@PART[TE_18_DRAGONV2_POD|TE_18_DRAGONV2_POD_I4|TE_20_CargoRodan]:HAS[!MODULE[BetterRCSDisabledTag]]:NEEDS[TundraExploration,!ROWaterfall]:AFTER[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX],0
 	{
@@ -256,7 +322,7 @@
 // SCALE PASS - Fix scaling issues with some parts that would otherwise make the plumes look really bad
 // This has to go after the FIX PASS because some fixes require the whole ModuleWaterfallFX module be torn down
 
-@PART[*]:HAS[@MODULE[ModuleWaterfallFX],@MODULE[ModuleRCSFX]:HAS[@var_CurveISP],!MODULE[BetterRCSDisabledTag]]:FOR[z_BetterRCS]:NEEDS[Waterfall,!ROWaterfall]
+@PART:HAS[@MODULE[ModuleWaterfallFX],@MODULE[ModuleRCSFX]:HAS[@var_CurveISP],!MODULE[BetterRCSDisabledTag]]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]:HAS[@CONTROLLER[rcs]],*
 	{
@@ -270,7 +336,7 @@
 			scaleX = #$scale$
 			@scaleX ^= :,.*$::
 			@scale[1,,] = #$scaleX$
-			!scaleX = dummy
+			!scaleX = DELETE
 		}
 	}
 }
@@ -285,7 +351,7 @@
 //Low Sea Level Pressure - BetterRCS_LowSLPressure
 //Low Universal Pressure - BetterRCS_LowVacSLPressure
 
-@PART[*]:HAS[@MODULE[ModuleRCSFX]:HAS[@var_CurveISP_VacParse:HAS[~key[Vac_LowPressure]]&@var_CurveISP_SLParse:HAS[~key[SL_LowPressure]]]]:FOR[z_BetterRCS]:NEEDS[Waterfall,!ROWaterfall]
+@PART:HAS[@MODULE[ModuleRCSFX]:HAS[@var_CurveISP_VacParse:HAS[~key[Vac_LowPressure]]&@var_CurveISP_SLParse:HAS[~key[SL_LowPressure]]]]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]:HAS[@CONTROLLER[rcs]],*
 	{
@@ -300,7 +366,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleRCSFX]:HAS[@var_CurveISP_VacParse:HAS[#key[Vac_LowPressure]]&@var_CurveISP_SLParse:HAS[~key[SL_LowPressure]]]]:FOR[z_BetterRCS]:NEEDS[Waterfall,!ROWaterfall]
+@PART:HAS[@MODULE[ModuleRCSFX]:HAS[@var_CurveISP_VacParse:HAS[#key[Vac_LowPressure]]&@var_CurveISP_SLParse:HAS[~key[SL_LowPressure]]]]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]:HAS[@CONTROLLER[rcs]],*
 	{
@@ -315,7 +381,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleRCSFX]:HAS[@var_CurveISP_VacParse:HAS[~key[Vac_LowPressure]]&@var_CurveISP_SLParse:HAS[#key[SL_LowPressure]]]]:FOR[z_BetterRCS]:NEEDS[Waterfall,!ROWaterfall]
+@PART:HAS[@MODULE[ModuleRCSFX]:HAS[@var_CurveISP_VacParse:HAS[~key[Vac_LowPressure]]&@var_CurveISP_SLParse:HAS[#key[SL_LowPressure]]]]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]:HAS[@CONTROLLER[rcs]],*
 	{
@@ -330,7 +396,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleRCSFX]:HAS[@var_CurveISP_VacParse:HAS[#key[Vac_LowPressure]]&@var_CurveISP_SLParse:HAS[#key[SL_LowPressure]]]]:FOR[z_BetterRCS]:NEEDS[Waterfall,!ROWaterfall]
+@PART:HAS[@MODULE[ModuleRCSFX]:HAS[@var_CurveISP_VacParse:HAS[#key[Vac_LowPressure]]&@var_CurveISP_SLParse:HAS[#key[SL_LowPressure]]]]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]:HAS[@CONTROLLER[rcs]],*
 	{
@@ -345,7 +411,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleRCSFX],!MODULE[BetterRCSDisabledTag]]:FOR[z_BetterRCS]:NEEDS[Waterfall,!ROWaterfall]
+@PART:HAS[@MODULE[ModuleRCSFX],!MODULE[BetterRCSDisabledTag]]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleRCSFX],*
 	{
@@ -358,7 +424,7 @@
 // OVERWRITE PASS - Special Fuel Types
 // We're going to change the templates to a set of unique templates for various RCS thruster types based on their fuel use, like Xenon, or Methalox, or Hydrolox engines.
 
-@PART[*]:HAS[@MODULE[ModuleRCSFX]:HAS[@PROPELLANT[LqdHydrogen]]]:FOR[z_BetterRCS]:NEEDS[Waterfall,!ROWaterfall]
+@PART:HAS[@MODULE[ModuleRCSFX]:HAS[@PROPELLANT[LqdHydrogen]]]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]:HAS[@CONTROLLER[rcs]],*
 	{
@@ -369,8 +435,7 @@
 	}
 }
 
-
-@PART[*]:HAS[@MODULE[ModuleRCSFX]:HAS[@PROPELLANT[LqdMethane]]]:FOR[z_BetterRCS]:NEEDS[Waterfall,!ROWaterfall]
+@PART:HAS[@MODULE[ModuleRCSFX]:HAS[@PROPELLANT[LqdMethane]]]:NEEDS[Waterfall,!ROWaterfall]:FOR[z_BetterRCS]
 {
 	@MODULE[ModuleWaterfallFX]:HAS[@CONTROLLER[rcs]],*
 	{
@@ -383,7 +448,7 @@
 
 // FLUFF PASS - Description Addition
 // This is where each part touched by BetterRCS gets a little addition to it's description. This does use a FINAL pass which I'm told is bad practice.
-@PART[*]:HAS[@MODULE[BetterRCSModifiedTag]]:LAST[z_BetterRCS]
+@PART:HAS[@MODULE[BetterRCSModifiedTag]]:LAST[z_BetterRCS]
 {
-  @description ^= :$: Better<color=orange>RCS</color> Configurated.:
+	@description ^= :$:\n\nBetter<color=orange>RCS</color> Configurated.:
 }


### PR DESCRIPTION
This PR has a bunch of things that I wanted to fix, like the plumes not showing up as well as position fixes. 

If you want to merge this, you can. But I can't make you if you don't want to. I just wanted to let people know that if they are still having issues with plumes showing up, they can use my fork instead.

Changes:
- Commented out the lines that stopped plumes from showing up
- Removed ``@PART[*]`` , as it is unnecessary and removing it would make JohnnyOThan proud
- Moved the ``FOR[z_BetterRCS]`` to the end of patches, as in MM syntax, ``FOR`` usually comes last
- Position fixes! Plumes now align with thruster nozzles for both Stock and Restock models. (See https://github.com/PorktoberRevolution/ReStocked/issues/1058 if you still see offset plumes)
- Updated the description patch to use a newLine (\n\n) so it wouldn't conflict with any other mods that patch part descriptions

Feel free to ping me if you have any questions, or don't like these changes. I'm still relatively new to GitHub.